### PR TITLE
CPO-32 - Add historyExists field

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/cpo/controllers/CasePaymentOrdersControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/cpo/controllers/CasePaymentOrdersControllerIT.java
@@ -138,6 +138,7 @@ class CasePaymentOrdersControllerIT extends BaseTest {
                     .andExpect(jsonPath("$.effective_from", is(EFFECTIVE_FROM.format(formatter))))
                     .andExpect(jsonPath("$.created_by", is(CREATED_BY_IDAM_MOCK)))
                     .andExpect(jsonPath("$.created_timestamp").exists())
+                    .andExpect(jsonPath("$.history_exists").exists())
                 .andReturn();
 
             UUID id = UUID.fromString(
@@ -208,6 +209,7 @@ class CasePaymentOrdersControllerIT extends BaseTest {
             assertEquals(CREATED_BY_IDAM_MOCK, savedEntity.get().getCreatedBy());
             assertNotNull(savedEntity.get().getCreatedTimestamp());
             assertTrue(beforeCreateTimestamp.isBefore(savedEntity.get().getCreatedTimestamp()));
+            assertFalse(savedEntity.get().getHistoryExists());
         }
 
         private void verifyDbCpoAuditValues(UUID id,
@@ -227,6 +229,7 @@ class CasePaymentOrdersControllerIT extends BaseTest {
             assertEquals(CREATED_BY_IDAM_MOCK, latestRevision.getEntity().getCreatedBy());
             assertNotNull(latestRevision.getEntity().getCreatedTimestamp());
             assertTrue(beforeCreateTimestamp.isBefore(latestRevision.getEntity().getCreatedTimestamp()));
+            assertFalse(latestRevision.getEntity().getHistoryExists());
         }
     }
 
@@ -839,7 +842,8 @@ class CasePaymentOrdersControllerIT extends BaseTest {
                 .andExpect(jsonPath("$.action").value(request.getAction()))
                 .andExpect(jsonPath("$.responsible_party").value(request.getResponsibleParty()))
                 .andExpect(jsonPath("$.created_by").value(CREATED_BY_IDAM_MOCK))
-                .andExpect(jsonPath("$.created_timestamp").exists());
+                .andExpect(jsonPath("$.created_timestamp").exists())
+                .andExpect(jsonPath("$.history_exists").exists());
         }
 
         private void verifyDbCpoValues(UpdateCasePaymentOrderRequest request,
@@ -856,6 +860,7 @@ class CasePaymentOrdersControllerIT extends BaseTest {
             assertEquals(CREATED_BY_IDAM_MOCK, updatedEntity.get().getCreatedBy());
             assertNotNull(updatedEntity.get().getCreatedTimestamp());
             assertTrue(previousCreatedTimestamp.isBefore(updatedEntity.get().getCreatedTimestamp()));
+            assertTrue(updatedEntity.get().getHistoryExists());
         }
 
         private void verifyDbCpoAuditValues(UpdateCasePaymentOrderRequest request,
@@ -874,6 +879,7 @@ class CasePaymentOrdersControllerIT extends BaseTest {
             assertEquals(CREATED_BY_IDAM_MOCK, latestRevision.getEntity().getCreatedBy());
             assertNotNull(latestRevision.getEntity().getCreatedTimestamp());
             assertTrue(previousCreatedTimestamp.isBefore(latestRevision.getEntity().getCreatedTimestamp()));
+            assertTrue(latestRevision.getEntity().getHistoryExists());
         }
 
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/cpo/utils/CasePaymentOrderEntityGenerator.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/cpo/utils/CasePaymentOrderEntityGenerator.java
@@ -40,6 +40,7 @@ public class CasePaymentOrderEntityGenerator {
                 .effectiveFrom(LocalDateTime.now())
                 .createdTimestamp(LocalDateTime.now())
                 .responsibleParty("ResponsibleParty" + Arrays.toString(RandomUtils.nextBytes(2)))
+                .historyExists(false)
                 .build();
 
 

--- a/src/main/java/uk/gov/hmcts/reform/cpo/data/CasePaymentOrderEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/cpo/data/CasePaymentOrderEntity.java
@@ -49,4 +49,6 @@ public class CasePaymentOrderEntity {
     @Column(length = 70)
     private String createdBy;
 
+    @Column(length = 70)
+    private Boolean historyExists;
 }

--- a/src/main/java/uk/gov/hmcts/reform/cpo/domain/CasePaymentOrder.java
+++ b/src/main/java/uk/gov/hmcts/reform/cpo/domain/CasePaymentOrder.java
@@ -28,4 +28,6 @@ public class CasePaymentOrder {
     private String orderReference;
 
     private String createdBy;
+
+    private Boolean historyExists;
 }

--- a/src/main/java/uk/gov/hmcts/reform/cpo/service/mapper/CasePaymentOrderMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/cpo/service/mapper/CasePaymentOrderMapper.java
@@ -15,14 +15,14 @@ public interface CasePaymentOrderMapper {
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "createdTimestamp", ignore = true)
-    @Mapping(target = "historyExists", expression = "false")
+    @Mapping(target = "historyExists", expression = "java(false)")
     CasePaymentOrderEntity toEntity(CreateCasePaymentOrderRequest createCasePaymentOrderRequest,
                                                 String createdBy);
 
     CasePaymentOrder toDomainModel(CasePaymentOrderEntity casePaymentOrderEntity);
 
     @Mapping(target = "createdTimestamp", expression = "java(java.time.LocalDateTime.now())")
-    @Mapping(target = "historyExists", expression = "true")
+    @Mapping(target = "historyExists", expression = "java(true)")
     void mergeIntoEntity(@MappingTarget CasePaymentOrderEntity target,
                          UpdateCasePaymentOrderRequest updateCasePaymentOrderRequest,
                          String createdBy);

--- a/src/main/java/uk/gov/hmcts/reform/cpo/service/mapper/CasePaymentOrderMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/cpo/service/mapper/CasePaymentOrderMapper.java
@@ -15,12 +15,14 @@ public interface CasePaymentOrderMapper {
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "createdTimestamp", ignore = true)
+    @Mapping(target = "historyExists", expression = "false")
     CasePaymentOrderEntity toEntity(CreateCasePaymentOrderRequest createCasePaymentOrderRequest,
                                                 String createdBy);
 
     CasePaymentOrder toDomainModel(CasePaymentOrderEntity casePaymentOrderEntity);
 
     @Mapping(target = "createdTimestamp", expression = "java(java.time.LocalDateTime.now())")
+    @Mapping(target = "historyExists", expression = "true")
     void mergeIntoEntity(@MappingTarget CasePaymentOrderEntity target,
                          UpdateCasePaymentOrderRequest updateCasePaymentOrderRequest,
                          String createdBy);

--- a/src/main/resources/db/migration/V20210422_32__CPO-32-AddHistoryExistsFlag.sql
+++ b/src/main/resources/db/migration/V20210422_32__CPO-32-AddHistoryExistsFlag.sql
@@ -1,0 +1,8 @@
+ALTER TABLE public.case_payment_orders
+     ADD COLUMN IF NOT EXISTS history_exists BOOLEAN;
+
+ALTER TABLE public.case_payment_orders_audit
+     ADD COLUMN IF NOT EXISTS history_exists BOOLEAN;
+
+ALTER TABLE public.case_payment_orders_audit
+     ADD COLUMN IF NOT EXISTS history_exists_mod BOOLEAN;

--- a/src/test/java/uk/gov/hmcts/reform/BaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/BaseTest.java
@@ -14,10 +14,10 @@ import java.util.UUID;
 
 public interface BaseTest {
 
-    public static final String ERROR_PATH_DETAILS = "$.details";
-    public static final String ERROR_PATH_ERROR = "$.error";
-    public static final String ERROR_PATH_MESSAGE = "$.message";
-    public static final String ERROR_PATH_STATUS = "$.status";
+    String ERROR_PATH_DETAILS = "$.details";
+    String ERROR_PATH_ERROR = "$.error";
+    String ERROR_PATH_MESSAGE = "$.message";
+    String ERROR_PATH_STATUS = "$.status";
 
     String CASE_ID_VALID_1 = "9511425043588823";
     String CASE_ID_VALID_2 = "9716401307140455";
@@ -33,14 +33,15 @@ public interface BaseTest {
     String CPO_ID_INVALID_1 = "160924";
     String CPO_ID_INVALID_2 = "160924 ";
 
-    public static final String ORDER_REFERENCE_VALID = "2021-11223344556";
-    public static final String ORDER_REFERENCE_INVALID = "2021-918425346";
+    String ORDER_REFERENCE_VALID = "2021-11223344556";
+    String ORDER_REFERENCE_INVALID = "2021-918425346";
     String ACTION = "action";
     String RESPONSIBLE_PARTY = "responsibleParty";
     LocalDateTime EFFECTIVE_FROM = LocalDateTime.of(2021, Month.MARCH, 24, 11, 48, 32);
 
     String CREATED_BY = "createdBy";
     LocalDateTime CREATED_TIMESTAMP = LocalDateTime.now();
+    Boolean HISTORY_EXISTS = false;
 
     default <T> Optional<List<T>> createInitialValuesList(final T[] initialValues) {
         return Optional.of(Arrays.asList(initialValues));
@@ -56,6 +57,7 @@ public interface BaseTest {
             .id(UUID.fromString(CPO_ID_VALID_1))
             .createdBy(CREATED_BY)
             .createdTimestamp(CREATED_TIMESTAMP)
+            .historyExists(false)
             .build();
     }
 
@@ -68,6 +70,7 @@ public interface BaseTest {
         entity.setOrderReference(ORDER_REFERENCE_VALID);
         entity.setCreatedBy(CREATED_BY);
         entity.setCreatedTimestamp(CREATED_TIMESTAMP);
+        entity.setHistoryExists(HISTORY_EXISTS);
         return entity;
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/cpo/service/mapper/CasePaymentOrderMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/cpo/service/mapper/CasePaymentOrderMapperTest.java
@@ -54,6 +54,8 @@ class CasePaymentOrderMapperTest implements BaseTest {
                      casePaymentOrder.getOrderReference(), mappedEntity.getOrderReference());
         assertEquals("Mapped entity created by should equals mocked entity created by",
                      casePaymentOrder.getCreatedBy(), mappedEntity.getCreatedBy());
+        assertEquals("Mapped entity created by should equals mocked entity history exists",
+                     casePaymentOrder.getHistoryExists(), mappedEntity.getHistoryExists());
     }
 
     @Test
@@ -82,6 +84,8 @@ class CasePaymentOrderMapperTest implements BaseTest {
                      entity.getOrderReference(), mappedDomainObject.getOrderReference());
         assertEquals("Mapped domain model created by should equals mocked domain model created by",
                      entity.getCreatedBy(), mappedDomainObject.getCreatedBy());
+        assertEquals("Mapped domain model created by should equals mocked domain model history exists",
+                     entity.getHistoryExists(), mappedDomainObject.getHistoryExists());
     }
 
     @DisplayName("should successfully map an create request into an entity")
@@ -107,6 +111,8 @@ class CasePaymentOrderMapperTest implements BaseTest {
                      request.getOrderReference(), mappedRequestEntity.getOrderReference());
         assertEquals("Mapped entity created by should equals mocked entity created by",
                      CREATED_BY, mappedRequestEntity.getCreatedBy());
+        assertEquals("Mapped entity created by should equals mocked entity history exists",
+                    HISTORY_EXISTS, mappedRequestEntity.getHistoryExists());
     }
 
     @DisplayName("should successfully merge an update request into an entity")
@@ -136,6 +142,8 @@ class CasePaymentOrderMapperTest implements BaseTest {
         assertNotNull("Merged created timestamp should be set", entity.getCreatedTimestamp());
         assertNotEquals("Merged created timestamp should have changed",
                         originalCreatedTimestamp, entity.getCreatedTimestamp());
+        assertNotEquals("Merged history exists should have changed",
+                        HISTORY_EXISTS, entity.getHistoryExists());
         // standard property checks
         assertEquals("Merged effective from should equal source effective from",
                      updateRequest.getEffectiveFrom(), entity.getEffectiveFrom());
@@ -174,6 +182,7 @@ class CasePaymentOrderMapperTest implements BaseTest {
         assertNotNull("Action should remain populated", entity.getAction());
         assertNotNull("Responsible party should remain populated", entity.getResponsibleParty());
         assertNotNull("Order reference should remain populated", entity.getOrderReference());
+        assertNotNull("History exists should remain populated", entity.getHistoryExists());
 
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CPO-32


### Change description ###
Add in history exists field and default the value when creating and updating case payment order


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
