### PR TITLE
RDM-12139 CVE-2021-29425 - bump up dependencies to resolve CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -273,6 +273,9 @@ dependencies {
   compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
   compile group: 'commons-validator', name: 'commons-validator', version: '1.7'
 
+  // CVE-2021-29425
+  compile group: 'commons-io', name: 'commons-io', version: '2.8.0'
+
   annotationProcessor group: 'org.mapstruct', name: 'mapstruct-processor', version: versions.mapstruct
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-12139

### Change description ###

bump up dependencies to resolve CVE-2021-29425

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
