### PR TITLE
CPO-44 - List ids/case_ids not found when returning 404 Not Found

### DIFF
--- a/src/functionalTest/resources/features/F-703 - getCasePaymentOrder/S-703.5.td.json
+++ b/src/functionalTest/resources/features/F-703 - getCasePaymentOrder/S-703.5.td.json
@@ -21,7 +21,7 @@
     "_extends_" : "Common_404_Response",
     "body" : {
       "exception" : "uk.gov.hmcts.reform.cpo.exception.CasePaymentOrderCouldNotBeFoundException",
-      "message" : "Case Payment Order does not exist.",
+      "message" : "The following Case Payment Orders do not exist : f9a1b999-999a-4dbe-999a-adbfbb398836,f9a1b999-999a-4dbe-999a-adbfbb398836",
       "path" : "/case-payment-orders",
       "details" : null
     }

--- a/src/functionalTest/resources/features/F-703 - getCasePaymentOrder/S-703.6.td.json
+++ b/src/functionalTest/resources/features/F-703 - getCasePaymentOrder/S-703.6.td.json
@@ -19,7 +19,7 @@
     "_extends_" : "Common_404_Response",
     "body" : {
       "exception" : "uk.gov.hmcts.reform.cpo.exception.CasePaymentOrderCouldNotBeFoundException",
-      "message" : "Case Payment Order does not exist.",
+      "message" : "The following Case Payment Orders do not exist : 1617017531060561,1617017629907038",
       "path" : "/case-payment-orders",
       "details" : null
     }

--- a/src/functionalTest/resources/features/F-704 - deleteCasePaymentOrder/CPOs_Deleted.td.json
+++ b/src/functionalTest/resources/features/F-704 - deleteCasePaymentOrder/CPOs_Deleted.td.json
@@ -16,7 +16,7 @@
     "_extends_" : "Common_404_Response",
     "body" : {
       "exception" : "uk.gov.hmcts.reform.cpo.exception.CasePaymentOrderCouldNotBeFoundException",
-      "message" : "Case Payment Order does not exist.",
+      "message" : "The following Case Payment Orders do not exist : ${[scenarioContext][parentContext][childContexts][Prerequisite_Create_CPO][testData][actualResponse][body][id]},${[scenarioContext][parentContext][childContexts][Prerequisite_Create_CPO_2][testData][actualResponse][body][id]}",
       "path" : "/case-payment-orders",
       "details" : null
     }

--- a/src/functionalTest/resources/features/F-704 - deleteCasePaymentOrder/S-704.5.td.json
+++ b/src/functionalTest/resources/features/F-704 - deleteCasePaymentOrder/S-704.5.td.json
@@ -22,7 +22,7 @@
     "_extends_" : "Common_404_Response",
     "body" : {
       "exception" : "uk.gov.hmcts.reform.cpo.exception.CasePaymentOrderCouldNotBeFoundException",
-      "message" : "Case Payment Order specified by IDs does not exist",
+      "message" : "The following Case Payment Orders do not exist : f9a1b999-999a-4dbe-999a-adbfbb398836",
       "path" : "/case-payment-orders",
       "details" : null
     }

--- a/src/functionalTest/resources/features/F-704 - deleteCasePaymentOrder/S-704.6.td.json
+++ b/src/functionalTest/resources/features/F-704 - deleteCasePaymentOrder/S-704.6.td.json
@@ -7,14 +7,12 @@
     "does not contain the search criteria parameters",
     "contains a 204",
     "contains an case_ids that doesn't exist in the Case Payment Orders database"
-
-
   ],
 
   "request" : {
     "_extends_": "Common_Request",
     "queryParams": {
-      "case_ids": "${[scenarioContext][childContexts][Prerequisite_Create_CPO][testData][actualResponse][body][case_id]},${[scenarioContext][childContexts][Prerequisite_Create_CPO_2][testData][actualResponse][body][case_id]},${[scenarioContext][customValues][GenerateCaseId]}"
+      "case_ids": "${[scenarioContext][childContexts][Prerequisite_Create_CPO][testData][actualResponse][body][case_id]},${[scenarioContext][childContexts][Prerequisite_Create_CPO_2][testData][actualResponse][body][case_id]},1617017531060561"
     }
   },
 
@@ -22,7 +20,7 @@
     "_extends_" : "Common_404_Response",
     "body" : {
       "exception" : "uk.gov.hmcts.reform.cpo.exception.CasePaymentOrderCouldNotBeFoundException",
-      "message" : "Case Payment Order specified by Case IDs does not exist",
+      "message" : "The following Case Payment Orders do not exist : 1617017531060561",
       "path" : "/case-payment-orders",
       "details" : null
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/cpo/controllers/CasePaymentOrdersControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/cpo/controllers/CasePaymentOrdersControllerIT.java
@@ -30,6 +30,7 @@ import uk.gov.hmcts.reform.cpo.utils.UIDService;
 import uk.gov.hmcts.reform.cpo.validators.ValidationError;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -1306,7 +1307,10 @@ class CasePaymentOrdersControllerIT extends BaseTest {
 
         switch (parameterName) {
             case IDS:
-                savedEntitiesUuids.add(UUID.randomUUID());
+                List<UUID> nonExistentUuids = new ArrayList<>();
+                nonExistentUuids.add(UUID.randomUUID());
+                nonExistentUuids.add(UUID.randomUUID());
+                savedEntitiesUuids.addAll(nonExistentUuids);
                 String[] savedEntitiesUuidsString =
                         savedEntitiesUuids.stream().map(UUID::toString).toArray(String[]::new);
                 queryParamName = IDS;
@@ -1315,21 +1319,31 @@ class CasePaymentOrdersControllerIT extends BaseTest {
                         AUTHORISED_CRUD_SERVICE,
                         Arrays.asList(savedEntitiesUuidsString),
                         null);
-                expectedErrorMessage = ValidationError.CPO_NOT_FOUND_BY_ID;
+                expectedErrorMessage = ValidationError.CPOS_NOT_FOUND
+                        + nonExistentUuids.get(0).toString()
+                        + ","
+                        + nonExistentUuids.get(1).toString();
                 break;
             case CASE_IDS:
                 List<String> savedEntitiesCaseIds = savedEntities.stream()
                         .map(CasePaymentOrderEntity::getCaseId)
                         .map(caseId -> Long.toString(caseId))
                         .collect(Collectors.toList());
-                savedEntitiesCaseIds.add(uidService.generateUID());
+
+                List<String> nonExistentCpoIdentifiers = new ArrayList<>();
+                nonExistentCpoIdentifiers.add(uidService.generateUID());
+                nonExistentCpoIdentifiers.add(uidService.generateUID());
+                savedEntitiesCaseIds.addAll(nonExistentCpoIdentifiers);
                 queryParamName = CASE_IDS;
                 queryParamValue = savedEntitiesCaseIds.toArray(String[]::new);
                 hasGeneratedLogAuditRequestMatcher = hasGeneratedLogAudit(auditOperationType,
                         AUTHORISED_CRUD_SERVICE,
                         null,
                         savedEntitiesCaseIds);
-                expectedErrorMessage = ValidationError.CPO_NOT_FOUND_BY_CASE_ID;
+                expectedErrorMessage = ValidationError.CPOS_NOT_FOUND
+                        + nonExistentCpoIdentifiers.get(0)
+                        + ","
+                        + nonExistentCpoIdentifiers.get(1);
                 break;
             default:
                 fail("Invalid query parameter name supplied");

--- a/src/main/java/uk/gov/hmcts/reform/cpo/controllers/CasePaymentOrdersController.java
+++ b/src/main/java/uk/gov/hmcts/reform/cpo/controllers/CasePaymentOrdersController.java
@@ -127,7 +127,8 @@ public class CasePaymentOrdersController {
             message = "One or more of the following reasons:"
                 + "\n1) " + ValidationError.CPO_FILTER_ERROR
                 + "\n2) " + ValidationError.CASE_ID_INVALID
-                + "\n3) " + ValidationError.ID_INVALID,
+                + "\n3) " + ValidationError.ID_INVALID
+                + "\n4) " + ValidationError.CPOS_NOT_FOUND,
             response = String.class,
             examples = @Example({
                 @ExampleProperty(
@@ -197,9 +198,8 @@ public class CasePaymentOrdersController {
             message = "One or more of the following reasons:"
                 + "\n1) " + ValidationError.ID_INVALID
                 + "\n2) " + ValidationError.CASE_ID_INVALID
-                + "\n3) " + ValidationError.CPO_NOT_FOUND_BY_ID
-                + "\n4) " + ValidationError.CPO_NOT_FOUND_BY_CASE_ID
-                + "\n5) " + ValidationError.CANNOT_DELETE_USING_IDS_AND_CASE_IDS,
+                + "\n3) " + ValidationError.CPOS_NOT_FOUND
+                + "\n4) " + ValidationError.CANNOT_DELETE_USING_IDS_AND_CASE_IDS,
             examples = @Example(value = {
                 @ExampleProperty(
                     value = "{\n"

--- a/src/main/java/uk/gov/hmcts/reform/cpo/repository/CasePaymentOrdersJpaRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/cpo/repository/CasePaymentOrdersJpaRepository.java
@@ -16,9 +16,7 @@ public interface CasePaymentOrdersJpaRepository extends JpaRepository<CasePaymen
 
     int deleteByCaseIdIsIn(Collection<Long> caseIds);
 
-    int countAllById(UUID uuid);
-
-    int countAllByCaseId(Long caseId);
+    boolean existsByCaseId(Long caseId);
 
     Page<CasePaymentOrderEntity> findByIdIn(List<UUID> ids, Pageable pageable);
 

--- a/src/main/java/uk/gov/hmcts/reform/cpo/repository/CasePaymentOrdersJpaRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/cpo/repository/CasePaymentOrdersJpaRepository.java
@@ -16,9 +16,9 @@ public interface CasePaymentOrdersJpaRepository extends JpaRepository<CasePaymen
 
     int deleteByCaseIdIsIn(Collection<Long> caseIds);
 
-    List<CasePaymentOrderEntity> findAllById(UUID uuid);
+    int countAllById(UUID uuid);
 
-    List<CasePaymentOrderEntity> findAllByCaseId(Long caseId);
+    int countAllByCaseId(Long caseId);
 
     Page<CasePaymentOrderEntity> findByIdIn(List<UUID> ids, Pageable pageable);
 

--- a/src/main/java/uk/gov/hmcts/reform/cpo/repository/CasePaymentOrdersJpaRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/cpo/repository/CasePaymentOrdersJpaRepository.java
@@ -16,6 +16,8 @@ public interface CasePaymentOrdersJpaRepository extends JpaRepository<CasePaymen
 
     int deleteByCaseIdIsIn(Collection<Long> caseIds);
 
+    List<CasePaymentOrderEntity> findAllById(UUID uuid);
+
     List<CasePaymentOrderEntity> findAllByCaseId(Long caseId);
 
     Page<CasePaymentOrderEntity> findByIdIn(List<UUID> ids, Pageable pageable);

--- a/src/main/java/uk/gov/hmcts/reform/cpo/repository/CasePaymentOrdersRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/cpo/repository/CasePaymentOrdersRepositoryImpl.java
@@ -46,7 +46,7 @@ public class CasePaymentOrdersRepositoryImpl implements CasePaymentOrdersReposit
     private void validateAllEntriesExistByCaseIds(List<Long> caseIds) {
         List<String> nonExistentCaseIds = new ArrayList<>();
         for (Long cid : caseIds) {
-            if (casePaymentOrdersJpaRepository.countAllByCaseId(cid) == 0) {
+            if (!casePaymentOrdersJpaRepository.existsByCaseId(cid)) {
                 nonExistentCaseIds.add(String.valueOf(cid));
             }
         }
@@ -56,7 +56,7 @@ public class CasePaymentOrdersRepositoryImpl implements CasePaymentOrdersReposit
     private void validateAllEntriesExistByUuid(List<UUID> uuids) {
         List<String> nonExistentUuids = new ArrayList<>();
         for (UUID uuid : uuids) {
-            if (casePaymentOrdersJpaRepository.countAllById(uuid) == 0) {
+            if (!casePaymentOrdersJpaRepository.existsById(uuid)) {
                 nonExistentUuids.add(uuid.toString());
             }
         }

--- a/src/main/java/uk/gov/hmcts/reform/cpo/repository/CasePaymentOrdersRepositoryImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/cpo/repository/CasePaymentOrdersRepositoryImpl.java
@@ -46,7 +46,7 @@ public class CasePaymentOrdersRepositoryImpl implements CasePaymentOrdersReposit
     private void validateAllEntriesExistByCaseIds(List<Long> caseIds) {
         List<String> nonExistentCaseIds = new ArrayList<>();
         for (Long cid : caseIds) {
-            if (casePaymentOrdersJpaRepository.findAllByCaseId(cid).isEmpty()) {
+            if (casePaymentOrdersJpaRepository.countAllByCaseId(cid) == 0) {
                 nonExistentCaseIds.add(String.valueOf(cid));
             }
         }
@@ -56,7 +56,7 @@ public class CasePaymentOrdersRepositoryImpl implements CasePaymentOrdersReposit
     private void validateAllEntriesExistByUuid(List<UUID> uuids) {
         List<String> nonExistentUuids = new ArrayList<>();
         for (UUID uuid : uuids) {
-            if (casePaymentOrdersJpaRepository.findAllById(uuid).isEmpty()) {
+            if (casePaymentOrdersJpaRepository.countAllById(uuid) == 0) {
                 nonExistentUuids.add(uuid.toString());
             }
         }

--- a/src/main/java/uk/gov/hmcts/reform/cpo/validators/ValidationError.java
+++ b/src/main/java/uk/gov/hmcts/reform/cpo/validators/ValidationError.java
@@ -17,8 +17,7 @@ public final class ValidationError {
     public static final String CPO_FILTER_ERROR = "Case payment orders cannot be filtered by both id and case id.";
     public static final String CPO_PAGE_ERROR = "Case Payment Order, Page index must not zero or be less than zero!";
 
-    public static final String CPO_NOT_FOUND_BY_ID = "Case Payment Order specified by IDs does not exist";
-    public static final String CPO_NOT_FOUND_BY_CASE_ID = "Case Payment Order specified by Case IDs does not exist";
+    public static final String CPOS_NOT_FOUND = "The following Case Payment Orders do not exist : ";
     public static final String CANNOT_DELETE_USING_IDS_AND_CASE_IDS =
             "Cannot delete Case Payment Orders by both ids and case-ids";
 

--- a/src/test/java/uk/gov/hmcts/reform/cpo/repository/CasePaymentOrdersRepositoryImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/cpo/repository/CasePaymentOrdersRepositoryImplTest.java
@@ -52,10 +52,10 @@ class CasePaymentOrdersRepositoryImplTest {
     @Test
     void testDeleteByUuids() {
         when(casePaymentOrdersJpaRepository.deleteByIdIsIn(anyList())).thenReturn(UUIDS.size());
-        when(casePaymentOrdersJpaRepository.countAllById(UUIDS.get(0)))
-                .thenReturn(1);
-        when(casePaymentOrdersJpaRepository.countAllById(UUIDS.get(1)))
-                .thenReturn(1);
+        when(casePaymentOrdersJpaRepository.existsById(UUIDS.get(0)))
+                .thenReturn(true);
+        when(casePaymentOrdersJpaRepository.existsById(UUIDS.get(1)))
+                .thenReturn(true);
 
         casePaymentOrdersRepository.deleteByUuids(UUIDS);
 
@@ -90,8 +90,8 @@ class CasePaymentOrdersRepositoryImplTest {
     @Test
     void testDeleteByCaseIds() {
         when(casePaymentOrdersJpaRepository.deleteByCaseIdIsIn(anyList())).thenReturn(CASE_IDS.size());
-        when(casePaymentOrdersJpaRepository.countAllByCaseId(anyLong()))
-                .thenReturn(1);
+        when(casePaymentOrdersJpaRepository.existsByCaseId(anyLong()))
+                .thenReturn(true);
 
         casePaymentOrdersRepository.deleteByCaseIds(CASE_IDS);
 
@@ -127,8 +127,8 @@ class CasePaymentOrdersRepositoryImplTest {
     @Test
     void testDeleteByCaseIdsMixOfExistingAndNonExistentCaseIds() {
         // Simulate 3 records existing with case id
-        when(casePaymentOrdersJpaRepository.countAllByCaseId(anyLong()))
-                .thenReturn(1);
+        when(casePaymentOrdersJpaRepository.existsByCaseId(anyLong()))
+                .thenReturn(true);
         when(casePaymentOrdersJpaRepository.deleteByCaseIdIsIn(anyList())).thenReturn(3);
 
         List<Long> caseIdToDelete = List.of(RandomUtils.nextLong());

--- a/src/test/java/uk/gov/hmcts/reform/cpo/repository/CasePaymentOrdersRepositoryImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/cpo/repository/CasePaymentOrdersRepositoryImplTest.java
@@ -12,7 +12,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.cpo.data.CasePaymentOrderEntity;
 import uk.gov.hmcts.reform.cpo.exception.CasePaymentOrderCouldNotBeFoundException;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -53,10 +52,10 @@ class CasePaymentOrdersRepositoryImplTest {
     @Test
     void testDeleteByUuids() {
         when(casePaymentOrdersJpaRepository.deleteByIdIsIn(anyList())).thenReturn(UUIDS.size());
-        when(casePaymentOrdersJpaRepository.findAllById(UUIDS.get(0)))
-                .thenReturn(List.of(new CasePaymentOrderEntity()));
-        when(casePaymentOrdersJpaRepository.findAllById(UUIDS.get(1)))
-                .thenReturn(List.of(new CasePaymentOrderEntity()));
+        when(casePaymentOrdersJpaRepository.countAllById(UUIDS.get(0)))
+                .thenReturn(1);
+        when(casePaymentOrdersJpaRepository.countAllById(UUIDS.get(1)))
+                .thenReturn(1);
 
         casePaymentOrdersRepository.deleteByUuids(UUIDS);
 
@@ -91,8 +90,8 @@ class CasePaymentOrdersRepositoryImplTest {
     @Test
     void testDeleteByCaseIds() {
         when(casePaymentOrdersJpaRepository.deleteByCaseIdIsIn(anyList())).thenReturn(CASE_IDS.size());
-        when(casePaymentOrdersJpaRepository.findAllByCaseId(anyLong()))
-                .thenReturn(Collections.singletonList(new CasePaymentOrderEntity()));
+        when(casePaymentOrdersJpaRepository.countAllByCaseId(anyLong()))
+                .thenReturn(1);
 
         casePaymentOrdersRepository.deleteByCaseIds(CASE_IDS);
 
@@ -128,8 +127,8 @@ class CasePaymentOrdersRepositoryImplTest {
     @Test
     void testDeleteByCaseIdsMixOfExistingAndNonExistentCaseIds() {
         // Simulate 3 records existing with case id
-        when(casePaymentOrdersJpaRepository.findAllByCaseId(anyLong()))
-                .thenReturn(Collections.singletonList(new CasePaymentOrderEntity()));
+        when(casePaymentOrdersJpaRepository.countAllByCaseId(anyLong()))
+                .thenReturn(1);
         when(casePaymentOrdersJpaRepository.deleteByCaseIdIsIn(anyList())).thenReturn(3);
 
         List<Long> caseIdToDelete = List.of(RandomUtils.nextLong());


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CPO-44

### Change description ###

When retrieving or deleting CPOs either by specifying UUIDs or case_id, if they do not exist in the database are we should we should list the respective missing case_id or ids in the 404 Not Found error message returned 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
