### PR TITLE
CCD-1245: Updated CCD definitions to 7.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -311,7 +311,7 @@ dependencies {
 
   integrationTestImplementation group: 'org.testcontainers', name: 'postgresql', version: versions.testcontainers
 
-  testImplementation group: 'com.github.hmcts', name: 'befta-fw', version: '6.14.2'
+  testImplementation group: 'com.github.hmcts', name: 'ccd-test-definitions', version: '7.0.0'
 
   functionalTestImplementation sourceSets.main.runtimeClasspath
   functionalTestImplementation sourceSets.test.runtimeClasspath

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,4 +20,7 @@
     ]]></notes>
     <cve>CVE-2021-29425</cve>
   </suppress>
+  <suppress>
+    <cve>CVE-2021-22118</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-1245 (https://tools.hmcts.net/jira/browse/CCD-1245)

### Change description ###
- Changed build.gradle to reference ccd-test-definitions version 7.0.0
instead of befta-fw version 6.14.2

This change has been made following the splitting of CCD logic and
data from the BEFTA framework core - see CCD-1223.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
