### PR TITLE
CCD-2120: Address CVE-2021-42340

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,7 +207,7 @@ def versions = [
   springCloud     : '2020.0.1',
   springfoxSwagger: '3.0.0',
   testcontainers  : '1.15.2',
-  tomcatEmbedded  : '9.0.50'
+  tomcatEmbedded  : '9.0.54'
 ]
 
 ext['spring-framework.version'] = '5.3.7'
@@ -303,7 +303,7 @@ dependencies {
 
   // CVE-2021-29425
   compile group: 'commons-io', name: 'commons-io', version: '2.8.0'
-  
+
 
   compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
   compileOnly group: 'org.mapstruct', name: 'mapstruct', version: versions.mapstruct

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  
+
   <suppress>
     <notes>
-			Declared as False positive on library com.nimbusds:lang-tag #3594 
+			Declared as False positive on library com.nimbusds:lang-tag #3594
 			https://github.com/jeremylong/DependencyCheck/issues/3594
 			CVE-2020-23171 Reference https://tools.hmcts.net/jira/browse/CCD-1873
     </notes>
@@ -18,11 +18,6 @@
    ]]></notes>
     <cpe>cpe:/a:pivotal_software:spring_security</cpe>
     <cve>CVE-2018-1258</cve>
-  </suppress>
-
-  <suppress until="2021-11-25">
-    <notes>Suppress CVE affecting Tomcat temporarily until it can be addressed</notes>
-    <cve>CVE-2021-42340</cve>
   </suppress>
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2120 (https://tools.hmcts.net/jira/browse/CCD-2120)


### Change description ###
Updated build.gradle.  Set value of tomcatEmbedded property to 9.0.54 to resolve CVE-2021-42340.
Removed suppression of CVE-2021-42340 from suppressions.xml.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
