### PR TITLE
CCD-2143: Address CVE-2021-22096

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ def versions = [
   tomcatEmbedded  : '9.0.54'
 ]
 
-ext['spring-framework.version'] = '5.3.7'
+ext['spring-framework.version'] = '5.3.12'
 
 // before committing a change, make sure task still works
 dependencyUpdates {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,9 +20,4 @@
     <cve>CVE-2018-1258</cve>
   </suppress>
 
-  <suppress until="2021-11-25">
-    <notes>Temp suppression to unblock pipeline.</notes>
-    <cve>CVE-2021-22096</cve>
-  </suppress>
-
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -12,7 +12,7 @@
     <cve>CVE-2020-23171</cve>
 	</suppress>
 
-  <suppress until="2030-01-01">
+  <suppress until="2021-11-25">
     <notes><![CDATA[
      Suppressing as it's a false positive (see: https://pivotal.io/security/cve-2018-1258)
    ]]></notes>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2143 (https://tools.hmcts.net/jira/browse/CCD-2143)


### Change description ###
- Updated build.gradle. Set value of override of spring-framework.version property to 5.3.12 to address CVE-2021-22096.
- Removed temporary suppression of CVE-2021-22096 from suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
