### PR TITLE
CCD-2312: Temporarily disable Fortify Scan in nightly build

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -12,8 +12,9 @@ def product = "cpo"
 def component = "case-payment-orders-api"
 
 withNightlyPipeline(type, product, component) {
-  enableFortifyScan('ccd-aat')
-  after('fortify-scan') {
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
-  }
+  // Temporarily disable fortify scan stage until 'entitlementPreferenceType is not available' issue is fixed
+  //enableFortifyScan('ccd-aat')
+  //after('fortify-scan') {
+  //  steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
+  //}
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2312 (https://tools.hmcts.net/jira/browse/CCD-2312)


### Change description ###
Temporarily disable the Fortify Scan stage in the nightly build until 'entitlementPreferenceType is not available' issue is fixed.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
