### PR TITLE
CCD-3111: Updated spring-framework.version to 5.3.19, removed suppression for CVE-2022-22968

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,7 +212,7 @@ def versions = [
   tomcatEmbedded  : '9.0.58'
 ]
 
-ext['spring-framework.version'] = '5.3.18'
+ext['spring-framework.version'] = '5.3.19'
 ext['log4j2.version'] = '2.17.1'
 
 // before committing a change, make sure task still works

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -42,11 +42,4 @@
     <vulnerabilityName>CVE-2022-22965</vulnerabilityName>
   </suppress>
 
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-core-5.3.18.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
-  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3111

### Change description ###

Updated spring-framework.version to 5.3.19, removed suppression for CVE-2022-22968

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
