### PR TITLE
CVE-2022-29885: cpo-case-payment-orders-api fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -209,7 +209,7 @@ def versions = [
   springCloud     : '2020.0.1',
   springfoxSwagger: '3.0.0',
   testcontainers  : '1.15.2',
-  tomcatEmbedded  : '9.0.58'
+  tomcatEmbedded  : '9.0.63'
 ]
 
 ext['spring-framework.version'] = '5.3.20'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -29,14 +29,6 @@
     <vulnerabilityName>CVE-2022-22965</vulnerabilityName>
   </suppress>
 
-  <suppress until="2022-06-25">
-    <notes><![CDATA[
-   file name: spring-core-5.3.19.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
-    <cve>CVE-2022-22970</cve>
-  </suppress>
-
   <suppress>
     <notes>False-positive. See CCD-3253</notes>
     <cve>CVE-2016-1000027</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -29,20 +29,12 @@
     <vulnerabilityName>CVE-2022-22965</vulnerabilityName>
   </suppress>
 
-  <suppress>
+  <suppress until="2022-06-25">
     <notes><![CDATA[
-   file name: tomcat-embed-core-9.0.58.jar
+   file name: spring-core-5.3.19.jar
    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
-    <cve>CVE-2022-29885</cve>
-  </suppress>
-
-  <suppress>
-    <notes><![CDATA[
-   file name: tomcat-embed-websocket-9.0.58.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
-    <cve>CVE-2022-29885</cve>
+    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
+    <cve>CVE-2022-22970</cve>
   </suppress>
 
   <suppress>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3270

Upgrading tomcat version to 9.0.63.
The documentation of Apache Tomcat 10.1.0-M1 to 10.1.0-M14, 10.0.0-M1 to 10.0.20, 9.0.13 to 9.0.62 and 8.5.38 to 8.5.78 for the EncryptInterceptor incorrectly stated it enabled Tomcat clustering to run over an untrusted network. This was not correct.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
