### PR TITLE
CCD-3433 CVE-2022-34305 suppression moved from temp to false positive

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,11 +8,13 @@
       CVE-2018-1258 refer https://tools.hmcts.net/jira/browse/CCD-3413
       CVE-2016-1000027 refer https://tools.hmcts.net/jira/browse/CCD-3253
       CVE-2022-33915 refer https://tools.hmcts.net/jira/browse/CCD-3450
+      CVE-2022-34305 refer https://tools.hmcts.net/jira/browse/CCD-3433
     </notes>
     <cve>CVE-2020-23171</cve>
     <cve>CVE-2018-1258</cve>
     <cve>CVE-2016-1000027</cve>
     <cve>CVE-2022-33915</cve>
+    <cve>CVE-2022-34305</cve>
   </suppress>
   <!--End of false positives section -->
 
@@ -20,7 +22,6 @@
   <suppress>
     <notes>
       CVE-2022-29885 refer https://tools.hmcts.net/jira/browse/CCD-3270
-      CVE-2022-34305 refer https://tools.hmcts.net/jira/browse/CCD-3433
       CVE-2022-31569 refer https://tools.hmcts.net/jira/browse/CCD-3536
       CVE-2022-22978 refer https://tools.hmcts.net/jira/browse/CCD-3513
       CVE-2021-22112 refer https://tools.hmcts.net/jira/browse/CCD-3514
@@ -28,7 +29,6 @@
       CVE-2021-22044 refer https://tools.hmcts.net/jira/browse/CCD-3509
     </notes>
     <cve>CVE-2022-29885</cve>
-    <cve>CVE-2022-34305</cve>
     <cve>CVE-2022-31569</cve>
     <cve>CVE-2022-22978</cve>
     <cve>CVE-2021-22112</cve>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3433
CVE-2022-34305 suppression moved from temp to false positive

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
