### PR TITLE
CCD-3607: CVE-2022-31197 - Upgraded org.postgresql to 42.4.1 and removed temp suppression

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -352,7 +352,7 @@ dependencies {
   functionalTestImplementation sourceSets.main.runtimeClasspath
   functionalTestImplementation sourceSets.test.runtimeClasspath
 
-  runtime group: 'org.postgresql', name: 'postgresql', version: '42.3.5'
+  runtime group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
 }
 
 mainClassName = 'uk.gov.hmcts.reform.cpo.Application'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -26,7 +26,6 @@
       CVE-2021-22112 refer https://tools.hmcts.net/jira/browse/CCD-3514
       CVE-2022-22976 refer https://tools.hmcts.net/jira/browse/CCD-3515
       CVE-2021-22044 refer https://tools.hmcts.net/jira/browse/CCD-3509
-      CVE-2022-31197 refer https://tools.hmcts.net/jira/browse/CCD-3607
     </notes>
     <cve>CVE-2022-29885</cve>
     <cve>CVE-2022-34305</cve>
@@ -35,7 +34,6 @@
     <cve>CVE-2021-22112</cve>
     <cve>CVE-2022-22976</cve>
     <cve>CVE-2021-22044</cve>
-    <cve>CVE-2022-31197</cve>
   </suppress>
   <!--End of temporary suppression section -->
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3607

### Change description ###

CCD-3607: CVE-2022-31197 - Upgraded org.postgresql to 42.4.1 and removed temp suppression

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
