### PR TITLE
CCD-3649: Fix preview deploy issues

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -57,7 +57,7 @@ env.BEFTA_S2S_CLIENT_ID_OF_PAYMENT_APP = "payment_app"
 
 env.DEFAULT_COLLECTION_ASSERTION_MODE="UNORDERED"
 env.BEFTA_RESPONSE_HEADER_CHECK_POLICY="JUST_WARN"
-env.DEFINITION_STORE_URL_BASE = "http://ccd-definition-store-api-${definitionStoreDevelopPr}.service.core-compute-preview.internal".toLowerCase()
+env.DEFINITION_STORE_URL_BASE = "https://ccd-definition-store-api-${definitionStoreDevelopPr}.service.core-compute-preview.internal".toLowerCase()
 
 
 withPipeline(type, product, component) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-3649 (https://tools.hmcts.net/jira/browse/CCD-3649)


### Change description ###
Changed DEFINITION_STORE_URL_BASE URL value used for preview in Jenkinsfile_CNP to use https instead of http.

Although this component doesn't currently appear to use DEFINITION_STORE_URL_BASE for any tests in preview it's being correcting in case it is needed in the future.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
