### PR TITLE
CCD-3433 CVE-2022-34305 tomcat upgrade 9.0.65, suppression removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,7 +207,7 @@ def versions = [
   springCloud     : '2020.0.1',
   springfoxSwagger: '3.0.0',
   testcontainers  : '1.15.2',
-  tomcatEmbedded  : '9.0.63'
+  tomcatEmbedded  : '9.0.65'
 ]
 
 ext['spring-framework.version'] = '5.3.20'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -6,14 +6,12 @@
     <notes>
       CVE-2018-1258 refer https://tools.hmcts.net/jira/browse/CCD-3413
       CVE-2016-1000027 refer https://tools.hmcts.net/jira/browse/CCD-3253
-      CVE-2022-34305 refer https://tools.hmcts.net/jira/browse/CCD-3433
       CVE-2022-22978 refer https://tools.hmcts.net/jira/browse/CCD-3513
       CVE-2021-22112 refer https://tools.hmcts.net/jira/browse/CCD-3514
       CVE-2022-22976 refer https://tools.hmcts.net/jira/browse/CCD-3515
     </notes>
     <cve>CVE-2018-1258</cve>
     <cve>CVE-2016-1000027</cve>
-    <cve>CVE-2022-34305</cve>
     <cve>CVE-2022-22978</cve>
     <cve>CVE-2021-22112</cve>
     <cve>CVE-2022-22976</cve>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3433
CVE-2022-34305 tomcat upgrade 9.0.65


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
