### PR TITLE
CCD-4398 Upgrade dependencies to resolve CVE-2023-24998

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,7 @@ def versions = [
   springCloud     : '2021.0.3',
   springfoxSwagger: '3.0.0',
   testcontainers  : '1.15.2',
-  tomcatEmbedded  : '9.0.69',
+  tomcatEmbedded  : '9.0.73',
 ]
 
 ext['spring-framework.version'] = '5.3.20'
@@ -307,7 +307,7 @@ dependencies {
   compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
   compile group: 'commons-validator', name: 'commons-validator', version: '1.7'
 
-  // CVE-2021-29425
+  implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
   compile group: 'commons-io', name: 'commons-io', version: '2.8.0'
 
 

--- a/charts/cpo-case-payment-orders-api/Chart.yaml
+++ b/charts/cpo-case-payment-orders-api/Chart.yaml
@@ -3,10 +3,10 @@ appVersion: "1.0"
 description: A Helm chart for cpo-case-payment-orders-api App
 name: cpo-case-payment-orders-api
 home: https://github.com/hmcts/cpo-case-payment-orders-api
-version: 0.1.8
+version: 0.1.9
 maintainers:
   - name: HMCTS cpo team
 dependencies:
   - name: java
-    version: 4.0.12
+    version: 4.0.13
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
-        CVE-2022-45688 refer [Ticket]
-        CVE-2023-24998 refer [Ticket]</notes>
+        CVE-2022-45688 refer [Ticket]</notes>
     <cve>CVE-2022-45688</cve>
-    <cve>CVE-2023-24998</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-4398


### Change description ###
Upgrade tomcat and commons-fileupload  to resolve CVE-2023-24998

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
