### PR TITLE
CCD-5066 : Fix broken master pipeline due to CVE clash between DBs

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -35,8 +35,8 @@ jobs:
         continue-on-error: true
       - name: Run suppressCves
         run: ./gradlew suppressCves
-      - name: Run cleanSuppressions
-        run: ./gradlew cleanSuppressions
+      #- name: Run cleanSuppressions
+      #  run: ./gradlew cleanSuppressions
       - name: Commit
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,7 +8,7 @@
         CVE-2023-42795 refer [Ticket]
         CVE-2023-45648 refer [Ticket]
         CVE-2023-44487 refer [Ticket]
-        CVE-2023-45960 refer [Ticket]
+        CVE-2023-45960 [this needs to be removed as its not a vulnerability in the central db]
     </notes>
     <cve>CVE-2023-34035</cve>
     <cve>CVE-2023-34034</cve>
@@ -16,5 +16,6 @@
     <cve>CVE-2023-42795</cve>
     <cve>CVE-2023-45648</cve>
     <cve>CVE-2023-44487</cve>
+    <cve>CVE-2023-45960</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-5066

### Change description ###

Commented out './gradlew cleanSuppressions', re-added suppression

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
