### PR TITLE
Fix CVE-2023-34034 : bump spring-security.version to 6.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -215,7 +215,7 @@ def versions = [
   tomcatEmbedded  : '10.1.9',
 ]
 
-ext['spring-security.version'] = '6.1.0'
+ext['spring-security.version'] = '6.1.2'
 ext['spring-framework.version'] = '6.0.9'
 ext['log4j2.version'] = '2.17.1'
 ext['snakeyaml.version'] = '2.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,32 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
-        CVE-2022-1471 refer https://tools.hmcts.net/jira/browse/CCD-4454
-        CVE-2023-34035 refer [Ticket]
-        CVE-2023-34034 refer [Ticket]
-        CVE-2023-41080 refer [Ticket]
-        CVE-2023-42795 refer [Ticket]
-        CVE-2023-45648 refer [Ticket]
-        CVE-2023-44487 refer [Ticket]
-        CVE-2023-45960 [this needs to be removed as its not a vulnerability in the central db]
+        CVE-2023-35116 refer [Ticket]
+        CVE-2023-6378 refer [Ticket]
         CVE-2023-34053 refer [Ticket]
         CVE-2023-34055 refer [Ticket]
+        CVE-2023-34042 refer [Ticket]
+        CVE-2023-44487 refer [Ticket]
         CVE-2023-46589 refer [Ticket]
-        CVE-2023-6378 refer [Ticket]
-        CVE-2023-35116 refer [Ticket]
-    </notes>
-    <cve>CVE-2023-34035</cve>
-    <cve>CVE-2023-34034</cve>
+        CVE-2023-41080 refer [Ticket]
+        CVE-2023-42795 refer [Ticket]
+        CVE-2023-45648 refer [Ticket]</notes>
+    <cve>CVE-2023-35116</cve>
+    <cve>CVE-2023-6378</cve>
+    <cve>CVE-2023-34053</cve>
+    <cve>CVE-2023-34055</cve>
+    <cve>CVE-2023-34042</cve>
+    <cve>CVE-2023-44487</cve>
+    <cve>CVE-2023-46589</cve>
     <cve>CVE-2023-41080</cve>
     <cve>CVE-2023-42795</cve>
     <cve>CVE-2023-45648</cve>
-    <cve>CVE-2023-44487</cve>
-    <cve>CVE-2023-45960</cve>
-    <cve>CVE-2023-34053</cve>
-    <cve>CVE-2023-34055</cve>
-    <cve>CVE-2023-46589</cve>
-    <cve>CVE-2023-6378</cve>
-    <cve>CVE-2023-35116</cve>
   </suppress>
 </suppressions>
-


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-5185
Fix CVE-2023-34034 : bump spring-security.version to 6.1.2

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
