### PR TITLE
Fix CVE-2023-41080 : Update org.apache.tomcat.embed to 10.1.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,7 +212,7 @@ def versions = [
   springBoot      : springBoot.class.package.implementationVersion,
   springCloud     : '2022.0.3',
   testcontainers  : '1.18.3',
-  tomcatEmbedded  : '10.1.9',
+  tomcatEmbedded  : '10.1.13',
 ]
 
 ext['spring-security.version'] = '6.1.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,32 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
-        CVE-2022-1471 refer https://tools.hmcts.net/jira/browse/CCD-4454
-        CVE-2023-34035 refer [Ticket]
-        CVE-2023-34034 refer [Ticket]
-        CVE-2023-41080 refer [Ticket]
-        CVE-2023-42795 refer [Ticket]
-        CVE-2023-45648 refer [Ticket]
-        CVE-2023-44487 refer [Ticket]
-        CVE-2023-45960 [this needs to be removed as its not a vulnerability in the central db]
+        CVE-2023-35116 refer [Ticket]
+        CVE-2023-6378 refer [Ticket]
         CVE-2023-34053 refer [Ticket]
         CVE-2023-34055 refer [Ticket]
+        CVE-2023-34034 refer [Ticket]
+        CVE-2023-34035 refer [Ticket]
+        CVE-2023-44487 refer [Ticket]
         CVE-2023-46589 refer [Ticket]
-        CVE-2023-6378 refer [Ticket]
-        CVE-2023-35116 refer [Ticket]
-    </notes>
-    <cve>CVE-2023-34035</cve>
-    <cve>CVE-2023-34034</cve>
-    <cve>CVE-2023-41080</cve>
-    <cve>CVE-2023-42795</cve>
-    <cve>CVE-2023-45648</cve>
-    <cve>CVE-2023-44487</cve>
-    <cve>CVE-2023-45960</cve>
+        CVE-2023-42795 refer [Ticket]
+        CVE-2023-45648 refer [Ticket]</notes>
+    <cve>CVE-2023-35116</cve>
+    <cve>CVE-2023-6378</cve>
     <cve>CVE-2023-34053</cve>
     <cve>CVE-2023-34055</cve>
+    <cve>CVE-2023-34034</cve>
+    <cve>CVE-2023-34035</cve>
+    <cve>CVE-2023-44487</cve>
     <cve>CVE-2023-46589</cve>
-    <cve>CVE-2023-6378</cve>
-    <cve>CVE-2023-35116</cve>
+    <cve>CVE-2023-42795</cve>
+    <cve>CVE-2023-45648</cve>
   </suppress>
 </suppressions>
-


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-4972
Fix CVE-2023-41080 : Update org.apache.tomcat.embed to 10.1.13

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
