### PR TITLE
CCD-5201 Changed spring security to v 6.1.5 as it is the most recent sub versi…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -215,7 +215,7 @@ def versions = [
   tomcatEmbedded  : '10.1.13',
 ]
 
-ext['spring-security.version'] = '6.1.2'
+ext['spring-security.version'] = '6.1.5'
 ext['spring-framework.version'] = '6.0.9'
 ext['log4j2.version'] = '2.17.1'
 ext['snakeyaml.version'] = '2.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -5,7 +5,6 @@
         CVE-2023-6378 refer [Ticket]
         CVE-2023-34053 refer [Ticket]
         CVE-2023-34055 refer [Ticket]
-        CVE-2023-34042 refer [Ticket]
         CVE-2023-44487 refer [Ticket]
         CVE-2023-46589 refer [Ticket]
         CVE-2023-42795 refer [Ticket]
@@ -14,7 +13,6 @@
     <cve>CVE-2023-6378</cve>
     <cve>CVE-2023-34053</cve>
     <cve>CVE-2023-34055</cve>
-    <cve>CVE-2023-34042</cve>
     <cve>CVE-2023-44487</cve>
     <cve>CVE-2023-46589</cve>
     <cve>CVE-2023-42795</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-5201



### Change description ###
Changed spring security to v 6.1.5 as it is the most recent sub version which doesn't cause tests to fail.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
