### PR TITLE
CCD-5198 Updated Spring version to resolve CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -215,7 +215,7 @@ def versions = [
   tomcatEmbedded  : '10.1.13',
 ]
 
-ext['spring-security.version'] = '6.1.2'
+ext['spring-security.version'] = '6.1.5'
 ext['spring-framework.version'] = '6.0.9'
 ext['log4j2.version'] = '2.17.1'
 ext['snakeyaml.version'] = '2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -215,8 +215,8 @@ def versions = [
   tomcatEmbedded  : '10.1.13',
 ]
 
-ext['spring-security.version'] = '6.1.5'
-ext['spring-framework.version'] = '6.0.9'
+ext['spring-security.version'] = '6.1.2'
+ext['spring-framework.version'] = '6.0.14'
 ext['log4j2.version'] = '2.17.1'
 ext['snakeyaml.version'] = '2.0'
 ext['jackson.version'] = '2.16.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -3,7 +3,6 @@
     <notes>Temporary Suppression
         CVE-2023-6378 refer [Ticket]
         CVE-2024-1597 refer [Ticket]
-        CVE-2023-34053 refer [Ticket]
         CVE-2023-34055 refer [Ticket]
         CVE-2023-34042 refer [Ticket]
         CVE-2023-44487 refer [Ticket]
@@ -12,7 +11,6 @@
         CVE-2023-45648 refer [Ticket]</notes>
     <cve>CVE-2023-6378</cve>
     <cve>CVE-2024-1597</cve>
-    <cve>CVE-2023-34053</cve>
     <cve>CVE-2023-34055</cve>
     <cve>CVE-2023-34042</cve>
     <cve>CVE-2023-44487</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-5198


### Change description ###
Updated Spring version to 6.1.5 as 6.1.6 caused tests to fail.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
