### PR TITLE
CCD-5159:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -310,8 +310,8 @@ dependencies {
   implementation group: 'net.minidev', name: 'json-smart', version: '2.4.11'
 
   // CVE-2021-42550
-  implementation group: 'ch.qos.logback', name: 'logback-classic', version: versions.logback
-  implementation group: 'ch.qos.logback', name: 'logback-core', version: versions.logback
+  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.6'
+  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.6'
 
   implementation "org.apache.tomcat.embed:tomcat-embed-core:${versions.tomcatEmbedded}"
   implementation "org.apache.tomcat.embed:tomcat-embed-el:${versions.tomcatEmbedded}"

--- a/build.gradle
+++ b/build.gradle
@@ -206,7 +206,6 @@ def versions = [
   lombokMapBinding: '0.2.0',
   reformLogging   : '6.0.1',
   appInsights     : '2.4.1',
-  logback         : '1.4.7',
   springBoot      : springBoot.class.package.implementationVersion,
   springCloud     : '2022.0.3',
   testcontainers  : '1.18.3',

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
-        CVE-2023-6378 refer [Ticket]
         CVE-2024-1597 refer [Ticket]
         CVE-2023-34055 refer [Ticket]
         CVE-2023-44487 refer [Ticket]
         CVE-2023-46589 refer [Ticket]
         CVE-2023-42795 refer [Ticket]
         CVE-2023-45648 refer [Ticket]</notes>
-    <cve>CVE-2023-6378</cve>
     <cve>CVE-2024-1597</cve>
     <cve>CVE-2023-34055</cve>
     <cve>CVE-2023-44487</cve>


### PR DESCRIPTION
Fix CVE-2023-6378, upgrading logback-core and logback-classic from 1.2.10 to 1.5.6.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-5159


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
